### PR TITLE
Fix bug in mt_get_char

### DIFF
--- a/src/core/indexes/hashed.c
+++ b/src/core/indexes/hashed.c
@@ -60,7 +60,7 @@ uint32_t hashed_bucket(uint32_t buckets, multi_t key) {
 		}
 	}
 	else {
-		result = hash_fletcher32(mt_get_char(key), mt_get_length(key)) % buckets;
+		result = hash_fletcher32(mt_get_char(&key), mt_get_length(key)) % buckets;
 	}
 
 	return result;

--- a/src/core/strings/multi.c
+++ b/src/core/strings/multi.c
@@ -172,10 +172,15 @@ uint64_t mt_get_number(multi_t multi) {
  * @brief	Get a character pointer to the value of a multi-type object.
  * @param	multi	a pointer to the multi-type object to be examined.
  * @param	a pointer to the value of the input object, or NULL on failure.
+ * @return	null on error
  */
 char * mt_get_char(const multi_t *multi) {
 
 	char *result = NULL;
+
+	if (multi == NULL) {
+		return NULL;
+	}
 
 	switch (multi->type) {
 

--- a/src/core/strings/multi.c
+++ b/src/core/strings/multi.c
@@ -173,7 +173,7 @@ uint64_t mt_get_number(multi_t multi) {
  * @param	multi	a pointer to the multi-type object to be examined.
  * @param	a pointer to the value of the input object, or NULL on failure.
  */
-char * mt_get_char(multi_t *multi) {
+char * mt_get_char(const multi_t *multi) {
 
 	char *result = NULL;
 

--- a/src/core/strings/multi.c
+++ b/src/core/strings/multi.c
@@ -170,71 +170,71 @@ uint64_t mt_get_number(multi_t multi) {
 
 /**
  * @brief	Get a character pointer to the value of a multi-type object.
- * @param	multi	the multi-type object to be examined.
+ * @param	multi	a pointer to the multi-type object to be examined.
  * @param	a pointer to the value of the input object, or NULL on failure.
  */
-char * mt_get_char(multi_t multi) {
+char * mt_get_char(multi_t *multi) {
 
 	char *result = NULL;
 
-	switch (multi.type) {
+	switch (multi->type) {
 
 	// Strings
 	case (M_TYPE_STRINGER):
-		result = st_char_get(multi.val.st);
+		result = st_char_get(multi->val.st);
 		break;
 
 	case (M_TYPE_NULLER):
-		result = multi.val.ns;
+		result = multi->val.ns;
 		break;
 
 	case (M_TYPE_BLOCK):
-		result = multi.val.bl;
+		result = multi->val.bl;
 		break;
 
 	// Boolean
 	case (M_TYPE_BOOLEAN):
-		result = (char *)&(multi.val.binary);
+		result = (char *)&(multi->val.binary);
 		break;
 
 		// Unsigned integers
 	case (M_TYPE_UINT64):
-		result = (char *)&(multi.val.u64);
+		result = (char *)&(multi->val.u64);
 
 		break;
 	case (M_TYPE_UINT32):
-		result = (char *)&(multi.val.u32);
+		result = (char *)&(multi->val.u32);
 		break;
 	case (M_TYPE_UINT16):
-		result = (char *)&(multi.val.u16);
+		result = (char *)&(multi->val.u16);
 		break;
 	case (M_TYPE_UINT8):
-		result = (char *)&(multi.val.u8);
+		result = (char *)&(multi->val.u8);
 		break;
 
 		// Signed integers
 	case (M_TYPE_INT64):
-		result = (char *)&(multi.val.i64);
+		result = (char *)&(multi->val.i64);
 		break;
 	case (M_TYPE_INT32):
-		result = (char *)&(multi.val.i32);
+		result = (char *)&(multi->val.i32);
 		break;
 	case (M_TYPE_INT16):
-		result = (char *)&(multi.val.i16);
+		result = (char *)&(multi->val.i16);
 		break;
 	case (M_TYPE_INT8):
-		result = (char *)&(multi.val.i8);
+		result = (char *)&(multi->val.i8);
 		break;
 
 	case (M_TYPE_FLOAT):
-		result = (char *)&(multi.val.fl);
+		result = (char *)&(multi->val.fl);
 		break;
 	case (M_TYPE_DOUBLE):
-		result = (char *)&(multi.val.dbl);
+		result = (char *)&(multi->val.dbl);
 		break;
 
 	default:
-		log_options(M_LOG_INFO | M_LOG_STACK_TRACE, "The mt_get_char function was called on an unsupported data type. {type = %s = %u}", type(multi.type), multi.type);
+		log_options(M_LOG_INFO | M_LOG_STACK_TRACE, "The mt_get_char function was called on an unsupported data type. {type = %s = %u}", type(multi->type), multi->type);
 		break;
 	}
 

--- a/src/core/strings/strings.h
+++ b/src/core/strings/strings.h
@@ -228,7 +228,7 @@ int32_t    cmp_mt_mt(multi_t one, multi_t two);
 bool_t     ident_mt_mt(multi_t one, multi_t two);
 multi_t    mt_dupe(multi_t multi);
 void       mt_free(multi_t multi);
-char *     mt_get_char(multi_t *multi);
+char *     mt_get_char(const multi_t *multi);
 size_t     mt_get_length(multi_t multi);
 multi_t    mt_get_null(void);
 uint64_t   mt_get_number(multi_t multi);

--- a/src/core/strings/strings.h
+++ b/src/core/strings/strings.h
@@ -228,7 +228,7 @@ int32_t    cmp_mt_mt(multi_t one, multi_t two);
 bool_t     ident_mt_mt(multi_t one, multi_t two);
 multi_t    mt_dupe(multi_t multi);
 void       mt_free(multi_t multi);
-char *     mt_get_char(multi_t multi);
+char *     mt_get_char(multi_t *multi);
 size_t     mt_get_length(multi_t multi);
 multi_t    mt_get_null(void);
 uint64_t   mt_get_number(multi_t multi);


### PR DESCRIPTION
I found and fixed this while working on the build system, and it seemed important enough to merit its own pull request.  Can you guys double-check my logic here?  I'm pretty sure core/indexes/hashed.c is the only call site for this function.  Also note that I haven't built this on the vm yet.

There may be a more elegant fix, and I guess a test may be in order.  This pull request is just meant to open discussion.

This function was returning dangling pointers in some cases.  The
multi_t tagged union argument was passed by value and in some cases a
pointer was returned that referenced the contents of this union.

This appears to be a rather serious bug as hash buckets appear to be
computed using the returned pointer.

This commit passes a pointer to the tagged union rather than passing it
by value.