### PR TITLE
Fix dangling pointer returned by mail_get_chunk

### DIFF
--- a/src/core/strings/shortcuts.c
+++ b/src/core/strings/shortcuts.c
@@ -22,6 +22,28 @@ placer_t pl_null(void) {
 }
 
 /**
+ * @brief        Initialize an existing placer that wraps a data buffer of given
+ *               size.
+ * @param result a nonnull pointer to the placer that will store the result
+ * @param data   a pointer to the data to be wrapped.
+ * @param len    the length, in bytes, of the data.
+ * @return       a placer pointing to the specified data.
+ */
+void pl_replace(placer_t *result, void *data, size_t len) {
+	if (result == NULL) {
+		log_error("NULL result pointer passed to pl_replace");
+	}
+
+	if (data == NULL) {
+		log_error("NULL data pointer passed to pl_replace");
+	}
+
+	result->opts = PLACER_T | JOINTED | STACK | FOREIGNDATA;
+	result->data = data;
+	result->length = len;
+}
+
+/**
  * @brief	Return a placer wrapping a data buffer of given size.
  * @param	data	a pointer to the data to be wrapped.
  * @param	len		the length, in bytes, of the data.

--- a/src/core/strings/shortcuts.c
+++ b/src/core/strings/shortcuts.c
@@ -24,23 +24,28 @@ placer_t pl_null(void) {
 /**
  * @brief        Initialize an existing placer that wraps a data buffer of given
  *               size.
- * @param result a nonnull pointer to the placer that will store the result
+ * @param result a non-null pointer to the placer that will store the result
  * @param data   a pointer to the data to be wrapped.
  * @param len    the length, in bytes, of the data.
- * @return       a placer pointing to the specified data.
+ * @return       NULL on error or a pointer to a placer referencing the
+ *               specified data.
  */
-void pl_replace(placer_t *result, void *data, size_t len) {
+placer_t *pl_replace(placer_t *result, void *data, size_t len) {
 	if (result == NULL) {
 		log_error("NULL result pointer passed to pl_replace");
+		return NULL;
 	}
 
 	if (data == NULL) {
 		log_error("NULL data pointer passed to pl_replace");
+		return NULL;
 	}
 
 	result->opts = PLACER_T | JOINTED | STACK | FOREIGNDATA;
 	result->data = data;
 	result->length = len;
+
+	return result;
 }
 
 /**

--- a/src/core/strings/strings.h
+++ b/src/core/strings/strings.h
@@ -146,6 +146,7 @@ stringer_t * st_merge_opts(uint32_t opts, chr_t *format, ...);
 stringer_t * st_append_opts(size_t align, stringer_t *s, stringer_t *append);
 
 /// shortcuts.c
+void       pl_replace(placer_t *result, void *data, size_t len);
 chr_t *    pl_char_get(placer_t place);
 void *     pl_data_get(placer_t place);
 bool_t     pl_empty(placer_t place);

--- a/src/core/strings/strings.h
+++ b/src/core/strings/strings.h
@@ -146,7 +146,7 @@ stringer_t * st_merge_opts(uint32_t opts, chr_t *format, ...);
 stringer_t * st_append_opts(size_t align, stringer_t *s, stringer_t *append);
 
 /// shortcuts.c
-void       pl_replace(placer_t *result, void *data, size_t len);
+placer_t * pl_replace(placer_t *result, void *data, size_t len);
 chr_t *    pl_char_get(placer_t place);
 void *     pl_data_get(placer_t place);
 bool_t     pl_empty(placer_t place);

--- a/src/objects/mail/mail.h
+++ b/src/objects/mail/mail.h
@@ -139,7 +139,7 @@ size_t        mail_discover_insertion_point(stringer_t *message, stringer_t *par
 int_t         mail_discover_type(stringer_t *header);
 stringer_t *  mail_extract_tag(chr_t *stream, size_t length);
 stringer_t *  mail_get_boundary(stringer_t *header);
-stringer_t *  mail_get_chunk(stringer_t *message, stringer_t *boundary, int_t chunk);
+bool_t        mail_get_chunk(placer_t *result, stringer_t *message, stringer_t *boundary, int_t chunk);
 stringer_t *  mail_insert_chunk_base64(server_t *server, stringer_t *message, stringer_t *part, uint64_t signum, uint64_t sigkey, int_t disposition, int_t type, int_t encoding);
 stringer_t *  mail_insert_chunk_text(server_t *server, stringer_t *message, stringer_t *part, uint64_t signum, uint64_t sigkey, int_t disposition, int_t type, int_t encoding);
 int_t         mail_modify_part(server_t *server, mail_message_t *message, stringer_t *part, uint64_t signum, uint64_t sigkey, int_t disposition, int_t recursion);

--- a/src/objects/mail/mail.h
+++ b/src/objects/mail/mail.h
@@ -139,7 +139,7 @@ size_t        mail_discover_insertion_point(stringer_t *message, stringer_t *par
 int_t         mail_discover_type(stringer_t *header);
 stringer_t *  mail_extract_tag(chr_t *stream, size_t length);
 stringer_t *  mail_get_boundary(stringer_t *header);
-bool_t        mail_get_chunk(placer_t *result, stringer_t *message, stringer_t *boundary, int_t chunk);
+placer_t *    mail_get_chunk(placer_t *result, stringer_t *message, stringer_t *boundary, int_t chunk);
 stringer_t *  mail_insert_chunk_base64(server_t *server, stringer_t *message, stringer_t *part, uint64_t signum, uint64_t sigkey, int_t disposition, int_t type, int_t encoding);
 stringer_t *  mail_insert_chunk_text(server_t *server, stringer_t *message, stringer_t *part, uint64_t signum, uint64_t sigkey, int_t disposition, int_t type, int_t encoding);
 int_t         mail_modify_part(server_t *server, mail_message_t *message, stringer_t *part, uint64_t signum, uint64_t sigkey, int_t disposition, int_t recursion);

--- a/src/objects/mail/signatures.c
+++ b/src/objects/mail/signatures.c
@@ -537,11 +537,14 @@ stringer_t * mail_insert_chunk_text(server_t *server, stringer_t *message, strin
 }
 
 /**
- * @brief	Get a specified chunk (mime part) of a multipart mime message.
- * @param	message		a managed string containing the mime message to be parsed.
- * @param	boundary	a managed string containing the boundary used to split the multipart mime message.
- * @param	chunk		the one-index based chunk to be retrieved from the multipart message
- * @return	NULL on failure or a placer containing the specified chunk on success.
+ * @brief          Get a specified chunk (mime part) of a multipart mime
+ *                 message.
+ * @param message  a managed string containing the mime message to be parsed.
+ * @param boundary a managed string containing the boundary used to split the
+ *                 multipart mime message.
+ * @param chunk    the one-index based chunk to be retrieved from the multipart message
+ * @return         NULL on failure or a placer containing the specified chunk
+ *                 on success.
  */
 bool_t mail_get_chunk(placer_t *result, stringer_t *message, stringer_t *boundary, int_t chunk) {
 

--- a/src/objects/mail/signatures.c
+++ b/src/objects/mail/signatures.c
@@ -539,12 +539,13 @@ stringer_t * mail_insert_chunk_text(server_t *server, stringer_t *message, strin
 /**
  * @brief          Get a specified chunk (mime part) of a multipart mime
  *                 message.
+ * @param result   a pointer to the placer that will contain the result
  * @param message  a managed string containing the mime message to be parsed.
  * @param boundary a managed string containing the boundary used to split the
  *                 multipart mime message.
  * @param chunk    the one-index based chunk to be retrieved from the multipart message
- * @return         NULL on failure or a placer containing the specified chunk
- *                 on success.
+ * @return         NULL on failure or a pointer to the placer containing the
+ *                 specified chunk.
  */
 placer_t *mail_get_chunk(placer_t *result, stringer_t *message, stringer_t *boundary, int_t chunk) {
 

--- a/src/objects/mail/signatures.c
+++ b/src/objects/mail/signatures.c
@@ -549,6 +549,11 @@ stringer_t * mail_insert_chunk_text(server_t *server, stringer_t *message, strin
  */
 placer_t *mail_get_chunk(placer_t *result, stringer_t *message, stringer_t *boundary, int_t chunk) {
 
+	if (result == NULL) return NULL;
+	if (message == NULL) return NULL;
+	if (boundary == NULL) return NULL;
+	if (chunk <= 0) return NULL;
+
 	int_t found = 0;
 	size_t start = 0, length = 0, input = 0;
 

--- a/src/objects/mail/signatures.c
+++ b/src/objects/mail/signatures.c
@@ -549,10 +549,22 @@ stringer_t * mail_insert_chunk_text(server_t *server, stringer_t *message, strin
  */
 placer_t *mail_get_chunk(placer_t *result, stringer_t *message, stringer_t *boundary, int_t chunk) {
 
-	if (result == NULL) return NULL;
-	if (message == NULL) return NULL;
-	if (boundary == NULL) return NULL;
-	if (chunk <= 0) return NULL;
+	if (result == NULL) {
+		log_error("result is NULL");
+		return NULL;
+	}
+	if (message == NULL) {
+		log_error("message is NULL");
+		return NULL;
+	}
+	if (boundary == NULL) {
+		log_error("boundary is NULL");
+		return NULL;
+	}
+	if (chunk < 1) {
+		log_error("chunk index is less than one");
+		return NULL;
+	}
 
 	int_t found = 0;
 	size_t start = 0, length = 0, input = 0;


### PR DESCRIPTION
This fixes #17.

This code is *not* yet ready for merge, but as requested I'm going ahead and opening the pull request for discussion.  There aren't tests yet, but I will rectify this once I've added them to the build (or if someone else wants to play with it feel free).

As best I can ascertain, mail_get_chunk intends to initialize a placer_t controlled by the caller.  Currently it returns a dangling pointer instead.  This function can fail, so returning by value won't work.  We could do a heap allocation, but that doesn't seem appropriate to me given how this function is used.

This solution allocates a placer_t on the stack in the caller which is passed to mail_get_chunk via pointer.  Initializing a placer via pointer doesn't appear to be supported by the existing tools, so I've added the pl_replace function to the string tools in core.  There might be a more appropriate name.