### PR TITLE
Fixed broken link: hashicorp.com -> vagrantup.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ vagrant init lavabit/magma; vagrant up --provider libvirt
 vagrant init lavabit/magma; vagrant up --provider hyperv
 ```
 
-Images are available for alternate platforms [here](https://atlas.hashicorp.com/lavabit).
+Images are available for alternate platforms [here](https://app.vagrantup.com/lavabit).
 
 # Credits
 


### PR DESCRIPTION
Sorry for the small pull request but this broken link was bothering me.
I changed the link from [hashicorp.com](https://app.terraform.io/lavabit) to [vagrantup.com](https://app.vagrantup.com/lavabit).
This change reflects the link on [magmadaemon.org](https://magmadaemon.org).